### PR TITLE
Release 1.1.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,7 +13,7 @@ dependencies = [
 
 [[package]]
 name = "batch_apk_installer"
-version = "1.1.2"
+version = "1.1.3"
 dependencies = [
  "dirs",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "batch_apk_installer"
 description = "A command-line tool for batch installation of Android Packages (APKs)."
-version = "1.1.2"
+version = "1.1.3"
 edition = "2024"
 license = "MIT"
 authors = ["Matheus Amazonas"]

--- a/src/console.rs
+++ b/src/console.rs
@@ -1,3 +1,7 @@
 pub fn print_error(error: &str) {
 	eprintln!("\x1b[91m{error}\x1b[0m");
 }
+
+pub fn print_warning(message: &str) {
+	eprintln!("\x1b[93m{message}\x1b[0m");
+}

--- a/src/console.rs
+++ b/src/console.rs
@@ -1,0 +1,3 @@
+pub fn print_error(error: &str) {
+	eprintln!("\x1b[91m{error}\x1b[0m");
+}

--- a/src/installation.rs
+++ b/src/installation.rs
@@ -1,3 +1,4 @@
+use crate::console;
 use crate::device::Device;
 use crate::error::Error;
 use crate::package::Package;
@@ -37,6 +38,7 @@ impl CommandOutcome {
 pub struct DeviceInstallations {
 	device: Arc<Device>,
 	packages: Vec<Arc<Package>>,
+	warnings: Vec<String>,
 	uninstall_first: bool,
 }
 
@@ -46,7 +48,23 @@ impl DeviceInstallations {
 	) -> Vec<DeviceInstallations> {
 		let mut requests: Vec<DeviceInstallations> = Vec::new();
 		for device in devices {
-			let matches: Vec<_> = packages.iter().filter(|p| device.supports(p)).collect();
+			let mut matches: Vec<&Arc<Package>> = vec![];
+			let mut warnings: Vec<String> = vec![];
+			for package in packages.iter().filter(|p| device.supports(p)) {
+				// Check for duplicates.
+				if matches.iter().any(|p| p.id() == package.id()) {
+					let warning = format!(
+						"Duplicated {} package found for {}. Skipping {}.",
+						package.id(),
+						device,
+						package.path()
+					);
+					warnings.push(warning);
+				} else {
+					matches.push(package);
+				}
+			}
+			// Do not add empty installations.
 			if matches.is_empty() {
 				continue;
 			}
@@ -58,6 +76,7 @@ impl DeviceInstallations {
 			let installations = DeviceInstallations {
 				device: device.clone(),
 				packages,
+				warnings,
 				uninstall_first,
 			};
 			requests.push(installations);
@@ -70,6 +89,9 @@ impl DeviceInstallations {
 	}
 
 	pub fn perform(self) -> ReceiverStream<CommandOutcome> {
+		for warning in &self.warnings {
+			console::print_warning(warning);
+		}
 		let (tx, rx) = mpsc::channel(self.packages.len());
 		for package in self.packages {
 			let device = self.device.clone();

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,6 +11,7 @@ use std::process::{Command, Stdio};
 use std::sync::Arc;
 
 mod config;
+mod console;
 mod device;
 mod error;
 mod installation;
@@ -31,10 +32,6 @@ fn command_exists(command: &str, args: &str) -> bool {
 		.stderr(Stdio::null())
 		.status()
 		.is_ok()
-}
-
-fn print_error(error: &str) {
-	eprintln!("\x1b[91m{error}\x1b[0m");
 }
 
 fn get_parameters(args: &[String]) -> Result<(String, bool), Error> {
@@ -80,7 +77,7 @@ async fn main() {
 	let (packages_folder, uninstall) = match get_parameters(&args) {
 		Ok((packages_folder, uninstall)) => (packages_folder, uninstall),
 		Err(e) => {
-			print_error(&e.to_string());
+			console::print_error(&e.to_string());
 			process::exit(1);
 		}
 	};
@@ -89,7 +86,7 @@ async fn main() {
 		Ok(config) => config,
 		Err(e) => {
 			let message = format!("Error when loading config: {e}.");
-			print_error(&message);
+			console::print_error(&message);
 			process::exit(1)
 		}
 	};
@@ -97,12 +94,12 @@ async fn main() {
 	let devices: Vec<_> = match Device::get_devices(config.platforms()) {
 		Ok(devices) if !devices.is_empty() => devices.into_iter().map(Arc::new).collect(),
 		Ok(_) => {
-			print_error("No devices were found.");
+			console::print_error("No devices were found.");
 			process::exit(1)
 		}
 		Err(e) => {
 			let message = format!("Error when fetching devices: {e}.");
-			print_error(&message);
+			console::print_error(&message);
 			process::exit(1)
 		}
 	};
@@ -115,20 +112,20 @@ async fn main() {
 	let packages: Vec<_> = match Package::find_all(&packages_dir, config.packages()) {
 		Ok(packages) => packages.into_iter().map(Arc::new).collect(),
 		Err(e) => {
-			print_error(&e.to_string());
+			console::print_error(&e.to_string());
 			process::exit(1);
 		}
 	};
 
 	if packages.is_empty() {
-		print_error("No packages found.");
+		console::print_error("No packages found.");
 		process::exit(1);
 	}
 
 	let installs = DeviceInstallations::build_requests(&devices, &packages, uninstall);
 	match installs.len() {
 		0 => {
-			print_error("No installation requests found.");
+			console::print_error("No installation requests found.");
 			process::exit(1);
 		}
 		device_count => {
@@ -141,7 +138,7 @@ async fn main() {
 				match outcome.error() {
 					Some(e) => {
 						let error = format!("{description} failed: {e}.");
-						print_error(&error);
+						console::print_error(&error);
 					}
 					None => println!("\x1b[92m{description} completed successfully.\x1b[0m"),
 				}


### PR DESCRIPTION
# External changes
- Check for duplicated package installation (closes #10). The first instance of a package wins. Following ones are skipped and a warning will be printed for them.

# Internal changes
- Move console printing methods to new `console` module.